### PR TITLE
Added rgb_t constructors

### DIFF
--- a/bitmap_image.hpp
+++ b/bitmap_image.hpp
@@ -51,6 +51,9 @@ public:
 
    struct rgb_t
    {
+      rgb_t(){}
+      rgb_t(unsigned char _red, unsigned char _green, unsigned char _blue):
+      red(_red), green(_green), blue(_blue){}
       unsigned char   red;
       unsigned char green;
       unsigned char  blue;


### PR DESCRIPTION
Added for the rgb_t struct:
-Empty Constructor (For backward compatibility).
-An (R, G, B) Constructor.